### PR TITLE
.github: Add dependabot.yml file for scanning pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This is good practice and will allow us to automatically test for vulnerabilities.